### PR TITLE
Security-motivated dependency updates and related

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,8 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36
 
-    - python: "3.7"
-      env: TOXENV=py37
-
     - python: "3.5"
       env: TOXENV=py35-pylint
 
     - python: "3.6"
       env: TOXENV=py36-pylint
-
-    - python: "3.7"
-      env: TOXENV=py37-pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,20 +25,20 @@ matrix:
   fast_finish: true
   include:
 
-    - python: "3.4"
-      env: TOXENV=py34
-
     - python: "3.5"
       env: TOXENV=py35
 
     - python: "3.6"
       env: TOXENV=py36
 
-    - python: "3.4"
-      env: TOXENV=py34-pylint
+    - python: "3.7"
+      env: TOXENV=py37
 
     - python: "3.5"
       env: TOXENV=py35-pylint
 
     - python: "3.6"
       env: TOXENV=py36-pylint
+
+    - python: "3.7"
+      env: TOXENV=py37-pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-group: deprecated-2017Q2
+dist: xenial
 language: python
 cache: pip
 

--- a/old/__init__.py
+++ b/old/__init__.py
@@ -302,11 +302,14 @@ ENV_VAR_MAP = {
 }
 
 
+DB_SCHEME = 'mysql+pymysql'
+
+
 def build_sqlalchemy_url(settings):
     old_name = settings['old_name']
     if settings['db.rdbms'] == 'mysql':
         return urlunparse(ParseResult(
-            scheme='mysql+oursql',
+            scheme=DB_SCHEME,
             netloc='{user}:{password}@{host}:{port}'.format(
                 user=settings['db.user'],
                 password=settings['db.password'],

--- a/old/views/resources.py
+++ b/old/views/resources.py
@@ -698,7 +698,7 @@ class Resources(abc.ABC, ReadonlyResources):
         :param dict data: the data for the resource to be created.
         :returns: an SQLAlchemy model object representing the resource.
         """
-        return self.model_cls(**self._get_create_data(data))
+        return self.model_cls(**self._get_create_data(data))  # pylint: disable=not-callable
 
     def _post_create(self, resource_model):
         """Perform some action after creating a new resource model in the

--- a/old/views/resources.py
+++ b/old/views/resources.py
@@ -6,7 +6,7 @@ import logging
 from formencode.validators import Invalid
 import inflect
 from sqlalchemy.sql import asc
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, InternalError
 
 from old.lib.constants import (
     ALLOWED_FILE_TYPES,
@@ -254,7 +254,7 @@ class ReadonlyResources:
         query = self._filter_query(query)
         try:
             ret = add_pagination(query, python_search_params.get('paginator'))
-        except OperationalError:
+        except (OperationalError, InternalError):
             self.request.response.status_int = 400
             msg = ('The specified search parameters generated an invalid'
                    ' database query')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,11 +3,7 @@ docutils==0.12
 formencode==1.3.1
 inflect==0.2.5
 markdown==2.6.7
-# The oursql .zip URL seems to be needed in some cases. It can be commented out
-# if SQLite is going to be used.
-# oursql==0.9.4
-# https://launchpad.net/oursql/py3k/py3k-0.9.4/+download/oursql-0.9.4.zip
-git+https://github.com/sqlobject/oursql.git@py3k
+PyMySQL==0.9.2
 passlib==1.6.5
 Pillow==6.2.0
 pyramid==1.7.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,5 +16,5 @@ pyramid_debugtoolbar==3.0.4
 pyramid_jinja2==2.6.2
 python-magic==0.4.12
 requests==2.20.0
-SQLAlchemy==1.1.3
+SQLAlchemy==1.3.0
 waitress==1.4.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,12 +9,12 @@ markdown==2.6.7
 # https://launchpad.net/oursql/py3k/py3k-0.9.4/+download/oursql-0.9.4.zip
 git+https://github.com/sqlobject/oursql.git@py3k
 passlib==1.6.5
-Pillow==3.4.2
+Pillow==6.2.0
 pyramid==1.7.3
 pyramid_beaker==0.8
 pyramid_debugtoolbar==3.0.4
 pyramid_jinja2==2.6.2
 python-magic==0.4.12
-requests==2.11.1
+requests==2.20.0
 SQLAlchemy==1.1.3
-waitress==1.0.1
+waitress==1.4.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
 pylint==1.8.1
-pytest==3.0.3
+pytest>=3.6
 pytest-cov
 WebTest >= 1.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = True
 minversion = 2.7.0
-envlist = {py34,py35,py36}{,-pylint}
+envlist = {py35,py36,py37}{,-pylint}
 
 [testenv]
 setenv =
@@ -9,16 +9,6 @@ setenv =
     OLD_NAME_2_TESTS=oldtests2
     OLD_PERMANENT_STORE = test-store
     OLD_TESTING = 1
-
-[testenv:py34]
-commands =
-    pip install -r requirements/test.txt -e .
-    pytest old/tests/ -v
-
-[testenv:py34-pylint]
-commands =
-    pip install -r requirements/test.txt -e .
-    pylint old
 
 [testenv:py35]
 commands =
@@ -36,6 +26,16 @@ commands =
     pytest old/tests/ -v
 
 [testenv:py36-pylint]
+commands =
+    pip install -r requirements/test.txt -e .
+    pylint old
+
+[testenv:py37]
+commands =
+    pip install -r requirements/test.txt -e .
+    pytest old/tests/ -v
+
+[testenv:py37-pylint]
 commands =
     pip install -r requirements/test.txt -e .
     pylint old


### PR DESCRIPTION
- Update dependencies motivated by security considerations

    - Bump pillow from 3.4.2 to 6.2.0 in /requirements
    - Bump waitress from 1.0.1 to 1.4.2 in /requirements
    - Bump requests from 2.11.1 to 2.20.0 in /requirements
    - Bump pytest to >=3.6 to fix testing dependency conflict (Travis)

- Added a Pylint directive to ignore a not-callable warning.
- Stop supporting Py3.4. Python 3.4 does not support Pillow >= 6.2.0 and that dependency seems to be a security requirement.
- Bump travis image from trusty to xenial
- Remove Py3.7 from Travis CI (needs resolution, see https://github.com/dativebase/old-pyramid/issues/32)
- Bump SQLAlchemy from 1.1.3 to 1.3.0
- Replace OurSQL dep with PyMySQL 0.9.2
- Catch SQLA InternalError in Search endpoint

    - New PyMySQL driver throws SQLAlchemy's InternalError (not
      OperationalError) when a malformed regex is supplied. Catch this error
      and respond as with OperationalError, i.e., 400.

