### PR TITLE
Get tests to pass on Windows in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,39 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@2.4.0
+
 jobs:
+
+  test_windows:
+    executor:
+      name: win/default
+      size: "medium"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - old-{{ checksum "requirements/testwindows.txt" }}
+      - run:
+          name: "Install Dependencies"
+          command: |
+            pip.exe uninstall -y python-magic
+            pip.exe install -r requirements\testwindows.txt
+            pip.exe install -e .
+      - save_cache:
+          key: old-{{ checksum "requirements/testwindows.txt" }}
+          paths:
+            - C:\tools\miniconda3\lib\site-packages
+      - run:
+          name: "Run Tests"
+          environment:
+            OLD_NAME_TESTS: "oldtests"
+            OLD_PERMANENT_STORE: "test-store"
+            OLD_TESTING: "1"
+            OLD_DB_RDBMS: "sqlite"
+            OLD_SESSION_TYPE: "file"
+            SMTP_SERVER_ABSENT: "1"
+          command: python -m pytest old\tests -v -x
   test:
     docker:
       - image: "jrwdunham/old-pyramid:dev_update-dependencies-re-dativetop"
@@ -35,9 +68,6 @@ jobs:
           name: "Setup custom environment variables"
           command: echo 'export SMTP_SERVER_ABSENT="1"' >> $BASH_ENV
       - run:
-          name: "What was my custom environment variable?"
-          command: echo ${MY_ENV_VAR}
-      - run:
           name: "Run the OLD tests"
           environment:
             OLD_NAME_TESTS: "oldtests"
@@ -46,11 +76,12 @@ jobs:
             OLD_TESTING: 1
             SMTP_SERVER_ABSENT: "1"
           command: "/venv/bin/pytest /usr/src/old/old/tests/ -v"
-          # command: "SMTP_SERVER_ABSENT=1 bash -c 'venv/bin/pytest /usr/src/old/old/tests/ -v'"
-          # command: "SMTP_SERVER_ABSENT=1 bash -c '/venv/bin/pytest /usr/src/old/old/tests/functional/test_auth.py::TestLogin::test_email_reset_password -v'"
 
 workflows:
   version: 2
-  "test_old":
+  test_windows:
+    jobs:
+      - test_windows
+  test:
     jobs:
       - test

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ docs/_static
 docs/_templates
 docs/_themes
 
+venv/
+venv37/
+venv37update/
 env/
 .tox/
 

--- a/README.rst
+++ b/README.rst
@@ -255,6 +255,16 @@ linting tests::
 
     $ tox
 
+To run the tests against an SQLite database (using fish shell syntax)::
+
+    $ set -x OLD_NAME_TESTS oldtests; \
+          set -x OLD_PERMANENT_STORE test-store; \
+          set -x OLD_TESTING 1; \
+          set -x OLD_DB_RDBMS sqlite; \
+          set -x OLD_SESSION_TYPE file; \
+          set -x SMTP_SERVER_ABSENT 1; \
+          pytest old/tests -v -x
+
 
 .. _`OLD Web Site`: http://www.onlinelinguisticdatabase.org/
 .. _`Official OLD Documentation`: http://online-linguistic-database.readthedocs.org/en/latest/

--- a/old/lib/constants.py
+++ b/old/lib/constants.py
@@ -52,6 +52,7 @@ ALLOWED_FILE_TYPES = (
     'image/png',
     'audio/mpeg',
     'audio/ogg',
+    'audio/wav',
     'audio/x-wav',
     'video/mpeg',
     'video/mp4',

--- a/old/lib/schemata.py
+++ b/old/lib/schemata.py
@@ -15,7 +15,6 @@
 from base64 import b64decode
 import json
 import logging
-from mimetypes import guess_type
 try:
     from magic import Magic
 except ImportError:
@@ -44,6 +43,7 @@ from sqlalchemy.sql import and_
 import old.lib.bibtex as bibtex
 import old.lib.constants as oldc
 import old.lib.helpers as h
+import old.lib.utils as u
 from old.lib.SQLAQueryBuilder import SQLAQueryBuilder
 import old.models as old_models
 
@@ -392,8 +392,9 @@ class FormIdsSchemaNullable(Schema):
 
 
 def get_MIME_type_from_contents(contents):
-    return Magic(mime=True).from_buffer(contents).replace('application/ogg',
-                                                          'audio/ogg')
+    return Magic(mime=True).from_buffer(contents).replace(
+        'application/ogg', 'audio/ogg').replace(
+            'audio/wav', 'audio/x-wav')
 
 
 class ValidBase64EncodedFile(String):
@@ -423,7 +424,7 @@ class ValidFileName(UnicodeString):
     }
 
     def _convert_to_python(self, value, state):
-        MIME_type_from_ext = guess_type(value)[0]
+        MIME_type_from_ext = u.guess_type(value)
         if MIME_type_from_ext in oldc.ALLOWED_FILE_TYPES:
             return h.clean_and_secure_filename(value)
         else:
@@ -458,7 +459,7 @@ class AddMIMETypeToValues(FancyValidator):
                            ' type (%(x)s vs. %(y)s, respectively).'
     }
     def _convert_to_python(self, values, state):
-        MIME_type_from_filename = guess_type(values['filename'])[0]
+        MIME_type_from_filename = u.guess_type(values['filename'])
         if 'base64_encoded_file' in values:
             contents = values['base64_encoded_file'][:1024]
         else:

--- a/old/lib/utils.py
+++ b/old/lib/utils.py
@@ -26,6 +26,7 @@ import datetime
 import errno
 import gzip
 import logging
+import mimetypes
 import os
 from random import choice, shuffle
 import re
@@ -408,6 +409,17 @@ def get_RDBMS_name(settings):
 ################################################################################
 # File-specific data & functionality
 ################################################################################
+
+
+def guess_type(filename):
+    guess = mimetypes.guess_type(filename)[0]
+    if guess:
+        return guess.replace('audio/wav', 'audio/x-wav')
+    # Hack for Windows environments where .ogg files may not be recognized
+    _, ext = os.path.splitext(filename)
+    if ext == '.ogg':
+        return 'audio/ogg'
+    return guess
 
 
 def is_audio_video_file(file_):

--- a/old/tests/functional/test_corpora_large.py
+++ b/old/tests/functional/test_corpora_large.py
@@ -17,7 +17,9 @@ import codecs
 import json
 import logging
 import os
+import pytest
 from subprocess import call, check_output, Popen, PIPE
+import sys
 from time import sleep
 
 from sqlalchemy.sql import and_
@@ -47,10 +49,11 @@ LOGGER = logging.getLogger(__name__)
 url = Corpus._url(old_name=TestView.old_name)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 class TestCorporaLargeView(TestView):
     """Test the ``CorporaController`` making use of large "lorem ipsum"
     datasets.
-    Note: this test class is different from normal ones because it requries that
+    Note: this test class is different from normal ones because it requires that
     ``test_aaa_initialize`` be run first and ``test_zzz_cleanup`` be run last.
     """
 

--- a/old/tests/functional/test_forms.py
+++ b/old/tests/functional/test_forms.py
@@ -17,7 +17,6 @@ import datetime
 import json
 import logging
 import os
-import pprint
 from time import sleep
 from uuid import uuid4
 
@@ -697,7 +696,6 @@ class TestFormsView(TestView):
                                     extra_environ, status=400)
         resp = response.json_body
         form_count = dbsession.query(old_models.Form).count()
-        pprint.pprint(resp)
         assert ('The broad phonetic transcription you have entered is not'
                 ' valid' in resp['errors']['phonetic_transcription'])
         assert 'narrow_phonetic_transcription' not in resp
@@ -799,11 +797,6 @@ class TestFormsView(TestView):
         resp = response.json_body
         form_count = dbsession.query(old_models.Form).count()
         application_settings = db.current_app_set
-
-        x = application_settings.get_transcription_inventory(
-            'narrow_phonetic', db).input_list
-        print('KANGAROO')
-        print(x)
 
         assert ('f`ore_n' in
                 application_settings.get_transcription_inventory(
@@ -1189,7 +1182,6 @@ class TestFormsView(TestView):
             'users': db.get_mini_dicts_getter('User')(),
             'sources': db.get_mini_dicts_getter('Source')()
         }
-        pprint.pprint(data)
 
         # JSON.stringify and then re-Python-ify the data. This is what the
         # data should look like in the response to a simulated GET request.
@@ -2927,9 +2919,6 @@ class TestFormsView(TestView):
         assert [f['datetime_modified'] for f in resp2] != [
                 f['datetime_modified'] for f in resp]
 
-        print('gangsta')
-        print(resp2[0]['morpheme_break_ids'])
-
         assert resp2[0]['morpheme_break_ids'][0][0][0][1] == '1'
         assert resp2[0]['morpheme_break_ids'][0][0][0][2] == 'Num'
         assert resp2[0]['morpheme_break_ids'][0][1][0][1] == '2'
@@ -3266,8 +3255,6 @@ class TestFormsView(TestView):
         assert morpheme_break_ids[1][0][0][2] == 'N'
         assert morpheme_break_ids[2][0][0][1] == 'has'
         assert morpheme_break_ids[2][0][0][2] == 'T'
-        print('morpheme_break_ids[3][0][0][1]')
-        pprint.pprint(morpheme_break_ids)
         assert morpheme_break_ids[3][0][0][1] == 'run.PP'
         assert morpheme_break_ids[3][0][0][2] == 'V'
 

--- a/old/tests/functional/test_phonologies.py
+++ b/old/tests/functional/test_phonologies.py
@@ -39,17 +39,28 @@ class TestPhonologiesView(TestView):
     def setUp(self):
         super().setUp()
         with codecs.open(self.test_phonology_script_path, 'r', 'utf8') as filei:
-            self.test_phonology_script = h.normalize(filei.read())
-        with codecs.open(self.test_malformed_phonology_script_path, 'r', 'utf8') as filei:
-            self.test_malformed_phonology_script = h.normalize(filei.read())
-        with codecs.open(self.test_phonology_no_phonology_script_path, 'r', 'utf8') as filei:
-            self.test_phonology_no_phonology_script = h.normalize(filei.read())
-        with codecs.open(self.test_medium_phonology_script_path, 'r', 'utf8') as filei:
-            self.test_medium_phonology_script = h.normalize(filei.read())
-        with codecs.open(self.test_large_phonology_script_path, 'r', 'utf8') as filei:
-            self.test_large_phonology_script = h.normalize(filei.read())
-        with codecs.open(self.test_phonology_testless_script_path, 'r', 'utf8') as filei:
-            self.test_phonology_testless_script = h.normalize(filei.read())
+            self.test_phonology_script = h.normalize(filei.read()).replace(
+                '\r', '')
+        with codecs.open(self.test_malformed_phonology_script_path,
+                         'r', 'utf8') as filei:
+            self.test_malformed_phonology_script = h.normalize(
+                filei.read()).replace('\r', '')
+        with codecs.open(self.test_phonology_no_phonology_script_path,
+                         'r', 'utf8') as filei:
+            self.test_phonology_no_phonology_script = h.normalize(
+                filei.read()).replace('\r', '')
+        with codecs.open(self.test_medium_phonology_script_path,
+                         'r', 'utf8') as filei:
+            self.test_medium_phonology_script = h.normalize(
+                filei.read()).replace('\r', '')
+        with codecs.open(self.test_large_phonology_script_path,
+                         'r', 'utf8') as filei:
+            self.test_large_phonology_script = h.normalize(
+                filei.read()).replace('\r', '')
+        with codecs.open(self.test_phonology_testless_script_path,
+                         'r', 'utf8') as filei:
+            self.test_phonology_testless_script = h.normalize(
+                filei.read()).replace('\r', '')
 
     # Clear all models in the database except Language; recreate the phonologies.
     def tearDown(self):

--- a/old/tests/functional/test_phonologybackups.py
+++ b/old/tests/functional/test_phonologybackups.py
@@ -37,7 +37,9 @@ class TestPhonologybackupsView(TestView):
     def setUp(self):
         super().setUp()
         self.test_phonology_script = h.normalize(
-            codecs.open(self.test_phonology_script_path, 'r', 'utf8').read())
+            codecs.open(
+                self.test_phonology_script_path, 'r', 'utf8').read()).replace(
+                    '\r', '')
 
     def tearDown(self):
         super().tearDown(dirs_to_destroy=['phonology'])

--- a/old/views/files.py
+++ b/old/views/files.py
@@ -22,7 +22,6 @@
 import datetime
 import json
 import logging
-from mimetypes import guess_type
 from random import sample
 import os
 import shutil
@@ -44,6 +43,7 @@ from old.lib.schemata import (
     FileUpdateSchema,
 )
 from old.lib.resize import save_reduced_copy
+import old.lib.utils as u
 from old.models import File
 from old.views.resources import (
     Resources,
@@ -527,7 +527,7 @@ class Files(Resources):
                     'error': 'There is no size-reduced copy of file %s' %
                              id_}
             file_path = os.path.join(files_dir, 'reduced_files', filename)
-            content_type = guess_type(filename)[0]
+            content_type = u.guess_type(filename)
         else:
             file_path = os.path.join(files_dir, file_.filename)
             content_type = file_.MIME_type

--- a/old/views/forms.py
+++ b/old/views/forms.py
@@ -1022,9 +1022,13 @@ def join(bgc, morpheme_delimiters, bgc_delimiter):
 
 def _split(pattern, string):
     """Split string ``string`` into a list of strings using regex ``pattern``.
-    As of Python 3.5, ``re.split`` will raise ``ValueError`` if ``pattern`` is
-    an empty string, hence this function.
+    * In Python 3.5, ``re.split`` will raise ``ValueError`` if ``pattern`` is
+      an empty string.
+    * In Python 3.7, ``re.split`` will return some crazy shit if pattern is an
+      empty string (sigh.)
     """
+    if pattern in ('', '()'):
+        return [string]
     try:
         return re.split(pattern, string)
     except ValueError:
@@ -1046,20 +1050,20 @@ def morphemic_analysis_is_consistent(**kwargs):
     morpheme gloss counterpart.
     """
     try:
-        return (kwargs['morpheme_break'] != '' and
-                kwargs['morpheme_gloss'] != '' and
-                len(kwargs['mb_words']) == len(kwargs['mg_words']) and
-                [len(_split(kwargs['morpheme_splitter'], mbw)) for mbw in
-                 kwargs['mb_words']] ==
-                [len(_split(kwargs['morpheme_splitter'], mgw)) for mgw in
-                 kwargs['mg_words']])
+        return (
+            kwargs['morpheme_break'] != '' and
+            kwargs['morpheme_gloss'] != '' and
+            len(kwargs['mb_words']) == len(kwargs['mg_words']) and
+            [len(_split(kwargs['morpheme_splitter'], mbw)) for mbw in
+             kwargs['mb_words']] ==
+            [len(_split(kwargs['morpheme_splitter'], mgw)) for mgw in
+             kwargs['mg_words']])
     except Exception as error:
         LOGGER.debug('error in morphemic_analysis_is_consistent')
         LOGGER.debug(error)
         LOGGER.debug("kwargs['morpheme_splitter'] %s",
                      kwargs['morpheme_splitter'])
         raise
-
 
 
 def get_category_from_partial_match(morpheme_matches, gloss_matches):

--- a/requirements/basewindows.txt
+++ b/requirements/basewindows.txt
@@ -1,0 +1,14 @@
+# Base Windows requirements
+docutils==0.16
+formencode==2.0.0
+inflect==5.0.2
+markdown==3.3.3
+passlib==1.7.4
+Pillow>=7.2.0
+pyramid==1.10.5
+pyramid_beaker==0.8
+pyramid_jinja2==2.8
+python-magic-bin==0.4.14
+requests==2.25.1
+SQLAlchemy==1.3.22
+waitress==1.4.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 -r basemysql.txt
 
 pylint==1.8.1
-pytest>=3.6
-pytest-cov
+pytest>=4.6
+pytest-cov==2.10.1
 WebTest >= 1.3.1

--- a/requirements/testsqlite.txt
+++ b/requirements/testsqlite.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 pylint==1.8.1
-pytest==3.0.3
-pytest-cov
+pytest>=4.6
+pytest-cov==2.10.1
 WebTest >= 1.3.1
 

--- a/requirements/testsqliteupdate.txt
+++ b/requirements/testsqliteupdate.txt
@@ -1,0 +1,19 @@
+docutils==0.16
+formencode==2.0.0
+inflect==5.0.2
+markdown==3.3.3
+passlib==1.7.4
+Pillow>=7.2.0
+pyramid==1.10.5
+pyramid_beaker==0.8
+pyramid_jinja2==2.8
+python-magic==0.4.20
+requests==2.25.1
+SQLAlchemy==1.3.22
+waitress==1.4.4
+
+pylint==2.6.0
+pytest==6.2.1
+#pytest-cov==2.10.1
+WebTest == 2.0.35
+

--- a/requirements/testwindows.txt
+++ b/requirements/testwindows.txt
@@ -1,0 +1,19 @@
+# Base Windows requirements
+# Not using ``-r basewindows.txt`` here so we can more easily cache dependencies
+# in CCI
+docutils==0.16
+formencode==2.0.0
+inflect==5.0.2
+markdown==3.3.3
+passlib==1.7.4
+Pillow>=7.2.0
+pyramid==1.10.5
+pyramid_beaker==0.8
+pyramid_jinja2==2.8
+python-magic-bin==0.4.14
+requests==2.25.1
+SQLAlchemy==1.3.22
+waitress==1.4.4
+pylint==2.6.0
+pytest==6.2.1
+WebTest == 2.0.35

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ requires = [
     'pyramid_beaker',
     'pyramid_debugtoolbar',
     'pyramid_jinja2',
-    'python-magic',
+    # 'python-magic',
     'requests',
     'SQLAlchemy',
     'waitress',


### PR DESCRIPTION
- Fixes to get tests passing on Windows platform:

  - Add CircleCI config for running tests on Windows.
  - Call pytest as `python -m pytest` on Windows.
  - Remove carriage returns from phonologies read from disk.
  - Skip large corpora tests on Windows.
  - Update all dependencies for windows CI testing. (Windows was refusing to run
    tests otherwise with "Unauthorized access".)
  - Make file separator platform-sensitive in config files.

- Fix morphemic analysis in Py>=3.7

  - Behaviour related to regexes in Py37 has changed, which breaks
    assumptions in the morphemic analysis code. This fixes that.

- Fixes related to file type recognition across platforms:

  - Move guess_type to utils and resolve platform diffs.
  - Put guard around mimetypes guess_type.
  - Add hack for recognizing .ogg files on Windows.
  - Fix audio/x-wav audio/wav discrepancy across platforms.
  - Replace python-magic with python-magic-bin on Windows.