### PR TITLE
Add a /sync/last_modified endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ bootstrap-old:  ## Boostrap OLD (new database).
 		--entrypoint pserve config-env.ini \
 		old
 
-restart-old  ## Restart OLD
+restart-old:  ## Restart OLD
 	docker-compose restart old
 
 db:  ## Connect to the MySQL server using the CLI.
@@ -39,6 +39,15 @@ test-old:  ## Run OLD tests.
 		--workdir /usr/src/old \
 		--rm \
 		--entrypoint=pytest /usr/src/old/old/tests/ -v
+
+test-sqlite-part:  ## Run a particular test in a SQLite testing environment.
+	OLD_NAME_TESTS=oldtests \
+		OLD_PERMANENT_STORE=test-store \
+		OLD_TESTING=1 \
+		OLD_DB_RDBMS=sqlite \
+		OLD_SESSION_TYPE=file \
+		SMTP_SERVER_ABSENT=1 \
+		pytest $(part) -v -s -x
 
 help:  ## Print this help message.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.rst
+++ b/README.rst
@@ -255,16 +255,6 @@ linting tests::
 
     $ tox
 
-To run the tests against an SQLite database (using fish shell syntax)::
-
-    $ set -x OLD_NAME_TESTS oldtests; \
-          set -x OLD_PERMANENT_STORE test-store; \
-          set -x OLD_TESTING 1; \
-          set -x OLD_DB_RDBMS sqlite; \
-          set -x OLD_SESSION_TYPE file; \
-          set -x SMTP_SERVER_ABSENT 1; \
-          pytest old/tests -v -x
-
 
 .. _`OLD Web Site`: http://www.onlinelinguisticdatabase.org/
 .. _`Official OLD Documentation`: http://online-linguistic-database.readthedocs.org/en/latest/

--- a/old/models/__init__.py
+++ b/old/models/__init__.py
@@ -6,14 +6,14 @@ from sqlalchemy.orm import configure_mappers, sessionmaker
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .applicationsettings import ApplicationSettings
-from .collection import Collection
+from .applicationsettings import ApplicationSettings, ApplicationSettingsUser
+from .collection import Collection, CollectionFile, CollectionTag
 from .collectionbackup import CollectionBackup
-from .corpus import Corpus
+from .corpus import Corpus, CorpusForm, CorpusTag, CorpusFile
 from .corpusbackup import CorpusBackup
 from .elicitationmethod import ElicitationMethod
-from .file import File
-from .form import Form
+from .file import File, FileTag
+from .form import Form, FormFile, FormTag, CollectionForm
 from .formbackup import FormBackup
 from .formsearch import FormSearch
 from .keyboard import Keyboard
@@ -21,7 +21,7 @@ from .language import Language
 from .model import Model
 from .morphemelanguagemodel import MorphemeLanguageModel
 from .morphemelanguagemodelbackup import MorphemeLanguageModelBackup
-from .morphologicalparser import MorphologicalParser
+from .morphologicalparser import MorphologicalParser, Parse
 from .morphologicalparserbackup import MorphologicalParserBackup
 from .morphology import Morphology
 from .morphologybackup import MorphologyBackup
@@ -34,7 +34,7 @@ from .speaker import Speaker
 from .syntacticcategory import SyntacticCategory
 from .tag import Tag
 from .translation import Translation
-from .user import User
+from .user import User, UserForm
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/old/routes.py
+++ b/old/routes.py
@@ -708,6 +708,17 @@ def includeme(config):
                     route_name='info',
                     request_method='GET',
                     renderer='json')
+    config.add_route(
+        'last_modified',
+        '{old_name}/sync/last_modified',
+        request_method='GET')
+    config.add_view(
+        'old.views.sync.Sync',
+        attr='last_modified',
+        route_name='last_modified',
+        request_method='GET',
+        renderer='json',
+        decorator=authenticate)
     # CORS preflight OPTIONS requests: don't interfere with them
     # TODO: test if this works.
     config.add_route('cors_proceed', '/{old_name}/*garbage', request_method='OPTIONS')

--- a/old/tests/functional/test_sync.py
+++ b/old/tests/functional/test_sync.py
@@ -1,0 +1,141 @@
+# Copyright 2021 Joel Dunham
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from base64 import encodebytes
+import datetime
+import json
+import logging
+import os
+from time import sleep
+from uuid import uuid4
+
+from sqlalchemy.sql import desc
+
+from old.lib.dbutils import DBUtils
+from old.lib.SQLAQueryBuilder import SQLAQueryBuilder
+import old.models.modelbuilders as omb
+import old.models as old_models
+import old.views.sync as sut
+from old.tests import TestView
+
+LOGGER = logging.getLogger(__name__)
+
+
+forms_url = old_models.Form._url(old_name=TestView.old_name)
+
+
+
+class TestSyncView(TestView):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    # Clear all models in the database except Language; recreate the users.
+    def tearDown(self):
+        super().tearDown(dirs_to_clear=['reduced_files_path', 'files_path'])
+
+    def get_table_expected(self, mdl):
+        return {str(r.id): r.datetime_modified.isoformat() for
+                r in self.dbsession.query(mdl).all()}
+
+    def get_expected(self):
+        return {t: self.get_table_expected(getattr(old_models, t)) for t in sut.RESOURCES}
+
+    def test_last_modified(self):
+
+        db = DBUtils(self.dbsession, self.settings)
+        url = '/{}/sync/last_modified'.format(self.old_name)
+
+        r1 = self.app.get(url, {},
+            headers=self.json_headers,
+            extra_environ=self.extra_environ_contrib).json_body
+        exp1 = self.get_expected()
+        assert exp1 == r1
+
+        # Create some forms and other data in the db
+        restricted_tag = omb.generate_restricted_tag()
+        application_settings = omb.generate_default_application_settings()
+        self.dbsession.add_all([application_settings, restricted_tag])
+        self.dbsession.commit()
+        restricted_tag = db.get_restricted_tag()
+
+        for i in range(10):
+            params = self.form_create_params.copy()
+            params.update({
+                'transcription': str(i),
+                'translations': [{'transcription': str(i), 'grammaticality': '' }]})
+            params = json.dumps(params)
+            response = self.app.post(
+                forms_url('create'), params, self.json_headers,
+                self.extra_environ_contrib)
+            resp = response.json_body
+            datetime_modified = resp['datetime_modified']
+
+        # Now the last_modified payload will contain 10 forms, 10
+        # translations, 1 app settings and 1 tag.
+        r2 = self.app.get(url, {},
+            headers=self.json_headers,
+            extra_environ=self.extra_environ_contrib).json_body
+        exp2 = self.get_expected()
+        assert exp2 == r2
+        assert 0 == len(r2['FormBackup'])
+        assert 0 == len(r2['FormTag'])
+        assert 10 == len(r2['Form'])
+        assert 10 == len(r2['Translation'])
+        assert 1 == len(r2['ApplicationSettings'])
+        assert 1 == len(r2['Tag'])
+
+        # Update one of the forms just created
+        params = self.form_create_params.copy()
+        form_id = sorted(r2['Form'])[0]
+        params.update({
+            'transcription': 'Updated!',
+            'translations': [{
+                'transcription': 'test_update_translation',
+                'grammaticality': ''
+            }],
+            'morpheme_break': 'a-b',
+            'morpheme_gloss': 'c-d',
+            'status': 'requires testing',
+            'tags': [restricted_tag.id]
+        })
+        params = json.dumps(params)
+        response = self.app.put(forms_url('update', id=form_id), params,
+                                self.json_headers, self.extra_environ_contrib)
+        resp = response.json_body
+
+        # Now we will have a FormBackup and a FormTag
+        r3 = self.app.get(url, {},
+            headers=self.json_headers,
+            extra_environ=self.extra_environ_contrib).json_body
+        exp3 = self.get_expected()
+        assert exp3 == r3
+        assert r2['Form'][form_id] != r3['Form'][form_id]
+        assert 1 == len(r3['FormBackup'])
+        assert 1 == len(r3['FormTag'])
+
+        # Delete the second form created
+        sec_form_id = str(sorted([int(i) for i in r2['Form']])[1])
+        response = self.app.delete(
+                forms_url('delete', id=sec_form_id),
+                extra_environ=self.extra_environ_contrib)
+
+        # Now we will have 2 FormBackups and 9 Forms
+        r4 = self.app.get(url, {},
+            headers=self.json_headers,
+            extra_environ=self.extra_environ_contrib).json_body
+        exp4 = self.get_expected()
+        assert exp4 == r4
+        assert 2 == len(r4['FormBackup'])
+        assert 9 == len(r4['Form'])

--- a/old/views/sync.py
+++ b/old/views/sync.py
@@ -1,0 +1,95 @@
+# Copyright 2021 Joel Dunham
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Requests under /sync/ are routed here. These endpoints are specialized for
+helping a follower OLD to synchronize with a leader.
+"""
+
+import logging
+
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+
+import old.models as old_models
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+RESOURCES = (
+    'ApplicationSettings',
+    'ApplicationSettingsUser',
+    'Collection',
+    'CollectionBackup',
+    'CollectionFile',
+    'CollectionForm',
+    'CollectionTag',
+    'Corpus',
+    'CorpusBackup',
+    'CorpusFile',
+    'CorpusForm',
+    'CorpusTag',
+    'ElicitationMethod',
+    'File',
+    'FileTag',
+    'Form',
+    'FormBackup',
+    'FormFile',
+    'FormSearch',
+    'FormTag',
+    'Keyboard',
+    # 'Language': {}, # Language is special (immutable) ...
+    'MorphemeLanguageModel',
+    'MorphemeLanguageModelBackup',
+    'MorphologicalParser',
+    'MorphologicalParserBackup',
+    'Morphology',
+    'MorphologyBackup',
+    'Orthography',
+    'Page',
+    'Parse',
+    'Phonology',
+    'PhonologyBackup',
+    'Source',
+    'Speaker',
+    'SyntacticCategory',
+    'Tag',
+    'Translation',
+    'User',
+    'UserForm',
+)
+
+
+class Sync:
+
+    def __init__(self, request):
+        self.request = request
+
+    def last_modified(self):
+        """Return a map whose keys are resource names and whose values are maps
+        from row IDs to row last_modified datet-time strings.
+        """
+        LOGGER.info('Returning last_modified information about this OLD.')
+        # Get OLD resources as a dict from resource names to lists of resource
+        # attributes.
+        resources = {}
+        for rname in RESOURCES:
+            resources[rname] = {}
+            model_cls = getattr(old_models, rname)
+            resources[rname] = dict(self.request.dbsession.query(
+                getattr(model_cls, 'id'),
+                getattr(model_cls, 'datetime_modified')).all())
+        LOGGER.info('Returned last_modified information about this OLD.')
+        return resources
+
+


### PR DESCRIPTION
## Rationale

Resolves https://github.com/dativebase/dativetop/issues/21

## Changes

- Add a `/sync/last_modified` endpoint that returns an object whose keys are model names and whose values are objects whose keys are model IDs and whose values are `datetime_modified` ISO 8601 strings.
- Add make rule `test-sqlite-part` for running a particular test in a SQLite testing environment.