### PR TITLE
Add read-only mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,18 @@ jobs:
             OLD_SESSION_TYPE: "file"
             SMTP_SERVER_ABSENT: "1"
           command: python -m pytest old\tests -v -x
+      - run:
+          name: "Run Read-only Mode Tests"
+          environment:
+            OLD_NAME_TESTS: "oldtests"
+            OLD_PERMANENT_STORE: "test-store"
+            OLD_TESTING: "1"
+            OLD_READONLY: "1"
+            OLD_DB_RDBMS: "sqlite"
+            OLD_SESSION_TYPE: "file"
+            SMTP_SERVER_ABSENT: "1"
+          command: python -m pytest old\tests\functional\test_readonly_mode.py::TestReadonlyMode::test_readonly_mode -v -x
+
   test:
     docker:
       - image: "jrwdunham/old-pyramid:dev_update-dependencies-re-dativetop"
@@ -68,14 +80,25 @@ jobs:
           name: "Setup custom environment variables"
           command: echo 'export SMTP_SERVER_ABSENT="1"' >> $BASH_ENV
       - run:
-          name: "Run the OLD tests"
+         name: "Run the OLD tests"
+         environment:
+           OLD_NAME_TESTS: "oldtests"
+           OLD_NAME_2_TESTS: "oldtests2"
+           OLD_PERMANENT_STORE: "/var/old/store"
+           OLD_TESTING: 1
+           SMTP_SERVER_ABSENT: "1"
+         command: "/venv/bin/pytest old/tests/ -v"
+      - run:
+          name: "Run Read-only Mode Tests"
           environment:
             OLD_NAME_TESTS: "oldtests"
-            OLD_NAME_2_TESTS: "oldtests2"
-            OLD_PERMANENT_STORE: "/var/old/store"
-            OLD_TESTING: 1
+            OLD_PERMANENT_STORE: "test-store"
+            OLD_TESTING: "1"
+            OLD_READONLY: "1"
+            OLD_DB_RDBMS: "sqlite"
+            OLD_SESSION_TYPE: "file"
             SMTP_SERVER_ABSENT: "1"
-          command: "/venv/bin/pytest /usr/src/old/old/tests/ -v"
+          command: "/venv/bin/pytest old/tests/functional/test_readonly_mode.py::TestReadonlyMode::test_readonly_mode -v"
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,16 @@ test-sqlite-part:  ## Run a particular test in a SQLite testing environment.
 		SMTP_SERVER_ABSENT=1 \
 		pytest $(part) -v -s -x
 
+test-readonly:  ## Run tests for read-only mode
+	OLD_NAME_TESTS=oldtests \
+		OLD_PERMANENT_STORE=test-store \
+		OLD_TESTING=1 \
+		OLD_READONLY=1 \
+		OLD_DB_RDBMS=sqlite \
+		OLD_SESSION_TYPE=file \
+		SMTP_SERVER_ABSENT=1 \
+		pytest old/tests/functional/test_readonly_mode.py::TestReadonlyMode::test_readonly_mode -v -s -x
+
 help:  ## Print this help message.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 

--- a/config.ini
+++ b/config.ini
@@ -165,6 +165,10 @@ sqlalchemy.pool_recycle = 3600
 # OLD_TESTING
 testing = 0
 
+# Set this to 1 if this OLD is being run in read-only mode
+# OLD_READONLY
+readonly = 0
+
 # Permanent Store: for storing binary files for corpora, files, users,
 # phonologies, etc. In the default case, these files will be under a
 # subdirectory of permanent_store with the name being the value of

--- a/old/__init__.py
+++ b/old/__init__.py
@@ -281,6 +281,7 @@ ENV_VAR_MAP = {
     'OLD_NAME_2_TESTS': 'old_name_2_tests',
     'OLD_TESTING': 'testing',
     # General OLD config
+    'OLD_READONLY': 'readonly',
     'OLD_CREATE_REDUCED_SIZE_FILE_COPIES': 'create_reduced_size_file_copies',
     'OLD_PREFERRED_LOSSY_AUDIO_FORMAT': 'preferred_lossy_audio_format',
     'OLD_PERMANENT_STORE': 'permanent_store',

--- a/old/lib/constants.py
+++ b/old/lib/constants.py
@@ -195,6 +195,9 @@ UNAUTHORIZED_MSG = {
     'error': 'You are not authorized to access this resource.'
 }
 
+READONLY_MODE_MSG = {
+    'error': 'This OLD is running in read-only mode. All attempts to mutate data will be rejected.'
+}
 
 UNAUTHENTICATED_MSG = {
     'error': 'Authentication is required to access this resource.'

--- a/old/tests/functional/test_readonly_mode.py
+++ b/old/tests/functional/test_readonly_mode.py
@@ -1,0 +1,113 @@
+# Copyright 2021 Joel Dunham
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.  #  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from base64 import encodebytes
+import datetime
+import json
+import logging
+import os
+import pprint
+from time import sleep
+from uuid import uuid4
+
+from sqlalchemy.sql import desc
+
+from old.lib.dbutils import DBUtils
+from old.lib.SQLAQueryBuilder import SQLAQueryBuilder
+import old.models.modelbuilders as omb
+import old.models as old_models
+from old.models import (
+    Form,
+    Tag,
+    User,
+)
+from old.models.form import FormFile
+from old.tests import TestView, add_SEARCH_to_web_test_valid_methods
+
+LOGGER = logging.getLogger(__name__)
+
+
+# Recreate the Pylons ``url`` global function that gives us URL paths for a
+# given (resource) route name plus path variables as **kwargs
+url = Form._url(old_name=TestView.old_name)
+files_url = old_models.File._url(old_name=TestView.old_name)
+
+
+class TestReadonlyMode(TestView):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        add_SEARCH_to_web_test_valid_methods()
+
+    # Clear all models in the database except Language; recreate the users.
+    def tearDown(self):
+        super().tearDown(dirs_to_clear=['reduced_files_path', 'files_path'])
+
+    def test_readonly_mode(self):
+        if self.settings.get('readonly') == '0':
+            return
+
+        # Create form requests fail in read-only mode
+        params = self.form_create_params.copy()
+        params.update({
+            'transcription': 'test_create_transcription',
+            'translations': [{
+                'transcription': 'test_create_translation',
+                'grammaticality': ''
+            }],
+            'status': 'tested'
+        })
+        params = json.dumps(params)
+        response = self.app.post(url('create'), params, self.json_headers,
+                                 self.extra_environ_contrib, status=403).json_body
+        exp_msg = ('This OLD is running in read-only mode. All attempts to'
+                   ' mutate data will be rejected.')
+        assert exp_msg == response['error']
+
+        # Update form requests fail in read-only mode
+        response = self.app.put(url('update', id=1), params,
+                                self.json_headers,
+                                self.extra_environ_contrib, status=403).json_body
+        assert exp_msg == response['error']
+
+        # Delete form requests fail in read-only mode
+        response = self.app.delete(
+            url('delete', id=1), extra_environ=self.extra_environ_contrib,
+            status=403).json_body
+        assert exp_msg == response['error']
+
+        # Remember requests fail in read-only mode
+        response = self.app.post(
+            '/{}/forms/remember'.format(self.old_name),
+            json.dumps({'forms': [1]}),
+            headers=self.json_headers,
+            extra_environ=self.extra_environ_contrib,
+            status=403).json_body
+        assert exp_msg == response['error']
+
+        # Updating morpheme references fails in read-only mode
+        response = self.app.put(
+            '/{}/forms/update_morpheme_references'.format(self.old_name),
+            headers=self.json_headers,
+            extra_environ=self.extra_environ_admin,
+            status=403).json_body
+        assert exp_msg == response['error']
+
+        # Creating a new tag fails in read-only mode
+        response = self.app.post(
+            '/{}/tags'.format(self.old_name),
+            json.dumps({'name': 'tag', 'description': 'Described.'}),
+            headers=self.json_headers,
+            extra_environ=self.extra_environ_contrib,
+            status=403).json_body
+        assert exp_msg == response['error']

--- a/old/tests/functional/test_sync.py
+++ b/old/tests/functional/test_sync.py
@@ -22,17 +22,64 @@ from uuid import uuid4
 
 from sqlalchemy.sql import desc
 
+import old.lib.constants as oldc
 from old.lib.dbutils import DBUtils
 from old.lib.SQLAQueryBuilder import SQLAQueryBuilder
 import old.models.modelbuilders as omb
 import old.models as old_models
-import old.views.sync as sut
 from old.tests import TestView
 
 LOGGER = logging.getLogger(__name__)
 
 
 forms_url = old_models.Form._url(old_name=TestView.old_name)
+
+
+# I don't know why I am failing to import this from old.views.sync in some
+# environments but not others. At any rate, I'm just copying it here as a
+# workaround.
+MODELS = (
+    'ApplicationSettings',
+    'ApplicationSettingsUser',
+    'Collection',
+    'CollectionBackup',
+    'CollectionFile',
+    'CollectionForm',
+    'CollectionTag',
+    'Corpus',
+    'CorpusBackup',
+    'CorpusFile',
+    'CorpusForm',
+    'CorpusTag',
+    'ElicitationMethod',
+    'File',
+    'FileTag',
+    'Form',
+    'FormBackup',
+    'FormFile',
+    'FormSearch',
+    'FormTag',
+    'Keyboard',
+    # 'Language': {}, # Language is special (immutable) ...
+    'MorphemeLanguageModel',
+    'MorphemeLanguageModelBackup',
+    'MorphologicalParser',
+    'MorphologicalParserBackup',
+    'Morphology',
+    'MorphologyBackup',
+    'Orthography',
+    'Page',
+    'Parse',
+    'Phonology',
+    'PhonologyBackup',
+    'Source',
+    'Speaker',
+    'SyntacticCategory',
+    'Tag',
+    'Translation',
+    'User',
+    'UserForm',
+)
 
 
 def debug_diff(prev, curr):
@@ -85,13 +132,13 @@ class TestSyncView(TestView):
         super().tearDown(dirs_to_clear=['reduced_files_path', 'files_path'])
 
     def get_table_expected(self, mdl):
-        return {str(r.id): r.datetime_modified.isoformat().replace('T', ' ') for
+        return {str(r.id): r.datetime_modified.strftime(oldc.ISO_STRFTIME) for
                 r in self.dbsession.query(mdl).all()}
 
     def get_expected(self):
         return {getattr(old_models, m).__table__.name:
                 self.get_table_expected(getattr(old_models, m))
-                for m in sut.MODELS}
+                for m in MODELS}
 
     def test_last_modified(self):
 

--- a/old/views/auth.py
+++ b/old/views/auth.py
@@ -6,7 +6,8 @@ from formencode.validators import Invalid
 from sqlalchemy.exc import SQLAlchemyError
 
 from old.lib.constants import (
-    JSONDecodeErrorResponse
+    JSONDecodeErrorResponse,
+    READONLY_MODE_MSG
 )
 from old.lib.schemata import (
     LoginSchema,
@@ -99,6 +100,10 @@ def email_reset_password(request):
     """
     LOGGER.info('Request for a password reset.')
     schema = PasswordResetSchema()
+    if self.request.registry.settings.get('readonly') == '1':
+        LOGGER.warning('Attempt to reset a password in read-only mode')
+        self.request.response.status_int = 403
+        return READONLY_MODE_MSG
     try:
         values = json.loads(request.body.decode(request.charset))
     except ValueError:

--- a/old/views/corpora.py
+++ b/old/views/corpora.py
@@ -215,6 +215,10 @@ class Corpora(Resources):
         """
         corpus, id_ = self._model_from_id()
         LOGGER.info('Attempting to write corpus %s to a file on disk', id_)
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to write a corpus to file in read-only mode')
+            self.request.response.status_int = 403
+            return oldc.READONLY_MODE_MSG
         if not corpus:
             self.request.response.status_int = 404
             msg = 'There is no corpus with id {}'.format(id_)

--- a/old/views/forms.py
+++ b/old/views/forms.py
@@ -33,6 +33,7 @@ from old.lib.constants import (
     DEFAULT_DELIMITER,
     FORM_REFERENCE_PATTERN,
     JSONDecodeErrorResponse,
+    READONLY_MODE_MSG,
     UNAUTHORIZED_MSG,
     UNKNOWN_CATEGORY,
 )
@@ -315,6 +316,10 @@ class Forms(Resources):
         """
         LOGGER.info('Attempting to remember forms for a user.')
         schema = FormIdsSchema
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to remember forms in read-only mode')
+            self.request.response.status_int = 403
+            return READONLY_MODE_MSG
         try:
             values = json.loads(self.request.body.decode(self.request.charset))
         except ValueError:
@@ -383,6 +388,10 @@ class Forms(Resources):
         """
         LOGGER.info('Attempting to update the morphological analysis-related'
                     ' attributes of all forms.')
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to update the morpheme references of the forms in read-only mode')
+            self.request.response.status_int = 403
+            return READONLY_MODE_MSG
         forms = self.db.get_forms()
         return self.update_morpheme_references_of_forms(
             self.db.get_forms(),

--- a/old/views/morphemelanguagemodels.py
+++ b/old/views/morphemelanguagemodels.py
@@ -39,6 +39,10 @@ class Morphemelanguagemodels(Resources):
         """
         langmod, id_ = self._model_from_id(eager=True)
         LOGGER.info('Attempting to generate morpheme language model %s.', id_)
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to generate a LM in read-only mode')
+            self.request.response.status_int = 403
+            return oldc.READONLY_MODE_MSG
         if not langmod:
             self.request.response.status_int = 404
             msg = 'There is no morpheme language model with id {}'.format(id_)
@@ -110,6 +114,10 @@ class Morphemelanguagemodels(Resources):
         langmod, id_ = self._model_from_id(eager=True)
         LOGGER.info('Attempting to compute the perplexity of morpheme language'
                     ' model %s.', id_)
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to compute the perplexity of a LM in read-only mode')
+            self.request.response.status_int = 403
+            return oldc.READONLY_MODE_MSG
         if not langmod:
             self.request.response.status_int = 404
             msg = 'There is no morpheme language model with id {}'.format(id_)

--- a/old/views/morphologicalparsers.py
+++ b/old/views/morphologicalparsers.py
@@ -84,6 +84,10 @@ class Morphologicalparsers(Resources):
             :mod:`onlinelinguisticdatabase.lib.foma_worker`.
         """
         LOGGER.info('Attempting to generate and compile a morphological parser.')
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to generate and compile a parser in read-only mode')
+            self.request.response.status_int = 403
+            return oldc.READONLY_MODE_MSG
         return self._generate_and_compile_morphparser()
 
     def generate(self):
@@ -99,6 +103,10 @@ class Morphologicalparsers(Resources):
             generation task has terminated.
         """
         LOGGER.info('Attempting to generate a morphological parser.')
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to generate a parser in read-only mode')
+            self.request.response.status_int = 403
+            return oldc.READONLY_MODE_MSG
         return self._generate_and_compile_morphparser(compile_=False)
 
     def applydown(self):

--- a/old/views/morphologies.py
+++ b/old/views/morphologies.py
@@ -71,6 +71,10 @@ class Morphologies(Resources):
             :mod:`old.lib.foma_worker`.
         """
         LOGGER.info('Attempting to generate and compile a morphology.')
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to generate and compile a morphology in read-only mode')
+            self.request.response.status_int = 403
+            return oldc.READONLY_MODE_MSG
         return self.generate_and_compile_morphology()
 
     def generate(self):
@@ -83,6 +87,10 @@ class Morphologies(Resources):
             determine when the generation task has terminated.
         """
         LOGGER.info('Attempting to generate a morphology.')
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to generate a morphology in read-only mode')
+            self.request.response.status_int = 403
+            return oldc.READONLY_MODE_MSG
         return self.generate_and_compile_morphology(compile_=False)
 
     def generate_and_compile_morphology(self, compile_=True):

--- a/old/views/phonologies.py
+++ b/old/views/phonologies.py
@@ -32,6 +32,10 @@ class Phonologies(Resources):
         """
         phonology, id_ = self._model_from_id(eager=True)
         LOGGER.info('Attempting to compile phonology %d', id_)
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to compile a phonology in read-only mode')
+            self.request.response.status_int = 403
+            return oldc.READONLY_MODE_MSG
         if not phonology:
             self.request.response.status_int = 404
             msg = 'There is no phonology with id {}'.format(id_)

--- a/old/views/rememberedforms.py
+++ b/old/views/rememberedforms.py
@@ -25,7 +25,8 @@ from formencode.validators import Invalid
 from sqlalchemy.orm import subqueryload
 
 from old.lib.constants import (
-    JSONDecodeErrorResponse
+    JSONDecodeErrorResponse,
+    READONLY_MODE_MSG
 )
 import old.lib.helpers as h
 from old.models import (
@@ -127,6 +128,10 @@ class Rememberedforms(Resources):
         id_ = self.request.matchdict['id']
         LOGGER.info('Attempting to update the forms remembered by user %d.',
                     id_)
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to update remembered forms in read-only mode')
+            self.request.response.status_int = 403
+            return READONLY_MODE_MSG
         user = self.request.dbsession.query(
             User).options(subqueryload(User.remembered_forms)).get(id_)
         schema = FormIdsSchemaNullable

--- a/old/views/resources.py
+++ b/old/views/resources.py
@@ -15,6 +15,7 @@ from old.lib.constants import (
     JSONDecodeErrorResponse,
     LANGUAGE_MODEL_TOOLKITS,
     MARKUP_LANGUAGES,
+    READONLY_MODE_MSG,
     SYNTACTIC_CATEGORY_TYPES,
     UNAUTHORIZED_MSG,
     USER_ROLES,
@@ -447,6 +448,10 @@ class Resources(abc.ABC, ReadonlyResources):
         """
         LOGGER.info('Attempting to create a new %s.', self.hmn_member_name)
         schema = self.schema_cls()
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to create a resource in read-only mode')
+            self.request.response.status_int = 403
+            return READONLY_MODE_MSG
         try:
             values = json.loads(self.request.body.decode(self.request.charset))
         except ValueError:
@@ -498,6 +503,10 @@ class Resources(abc.ABC, ReadonlyResources):
         """
         resource_model, id_ = self._model_from_id(eager=True)
         LOGGER.info('Attempting to update %s %s.', self.hmn_member_name, id_)
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to update a resource in read-only mode')
+            self.request.response.status_int = 403
+            return READONLY_MODE_MSG
         if not resource_model:
             self.request.response.status_int = 404
             msg = self._rsrc_not_exist(id_)
@@ -579,6 +588,10 @@ class Resources(abc.ABC, ReadonlyResources):
         """
         resource_model, id_ = self._model_from_id(eager=True)
         LOGGER.info('Attempting to delete %s %s.', self.hmn_member_name, id_)
+        if self.request.registry.settings.get('readonly') == '1':
+            LOGGER.warning('Attempt to delete a resource in read-only mode')
+            self.request.response.status_int = 403
+            return READONLY_MODE_MSG
         if not resource_model:
             self.request.response.status_int = 404
             msg = self._rsrc_not_exist(id_)

--- a/old/views/sync.py
+++ b/old/views/sync.py
@@ -22,6 +22,7 @@ import logging
 from sqlalchemy import text
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
+import old.lib.constants as oldc
 import old.models as old_models
 
 
@@ -75,6 +76,15 @@ MODELS = (
 TABLES = tuple(getattr(old_models, mname).__table__.name for mname in MODELS)
 
 
+def date_string(date_thing):
+    """Given a "date", return a string, where the date may already be a string
+    or it may be a `datetime.datetime` instance.
+    """
+    if isinstance(date_thing, str):
+        return date_thing.replace(' ', 'T')
+    return date_thing.strftime(oldc.ISO_STRFTIME)
+
+
 class Sync:
 
     def __init__(self, request):
@@ -88,8 +98,8 @@ class Sync:
         tables = {}
         for tname in TABLES:
             tables[tname] = {
-                r['id']: r['datetime_modified'] for r in
-                self.request.dbsession.execute(
+                r['id']: date_string(r['datetime_modified']) for
+                r in self.request.dbsession.execute(
                     text('select id, datetime_modified from {}'.format(tname)))}
         LOGGER.info('Returned last_modified information about this OLD.')
         return tables


### PR DESCRIPTION
## Rationale

Resolves https://github.com/dativebase/dativetop/issues/23

## Changes

- Add readonly (boolean int) setting to config
- Add read-only tests to CI
- Prohibit the following requests in read-only mode:
  - all create resource requests
  - all update resource requests
  - all delete resource requests
  - reset password
  - write corpus file
  - remember forms (or update remembered forms)
  - update morpheme references of forms
  - generate and/or compile foma-based entities
  - compute LM complexity