### PR TITLE
Fix read-only local config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
 
   test:
     docker:
-      - image: "jrwdunham/old-pyramid:dev_update-dependencies-re-dativetop"
+      - image: "jrwdunham/old-pyramid:2021-07-01"
         environment:
           OLD_DB_RDBMS: "mysql"
           OLD_DB_USER: "old"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN set -ex \
         apt-transport-https \
         curl \
         git \
+        openssh-client \
         python-software-properties \
         software-properties-common \
         libldap2-dev \

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,17 @@ Confirm that Python 3.6, Ffmpeg, foma, TGrep2, and MITLM are installed::
     # estimate-ngram -h
     MIT Language Modeling Toolkit 0.4.2
 
+After building the image as per above, you may wish to push it to Docker Hub::
+
+    $ docker tag dativebase/old jrwdunham/old-pyramid:2021-07-01
+    $ docker push jrwdunham/old-pyramid:2021-07-01
+
+The above may require logging out and then back in again::
+
+    $ docker logout
+    $ docker login
+
+
 
 Installation
 ===============================================================================

--- a/configlocal.ini
+++ b/configlocal.ini
@@ -161,6 +161,10 @@ sqlalchemy.pool_recycle = 3600
 # OLD_TESTING
 testing = 0
 
+# Set this to 1 if this OLD is being run in read-only mode
+# OLD_READONLY
+readonly = 1
+
 # Permanent Store: for storing binary files for corpora, files, users,
 # phonologies, etc. In the default case, these files will be under a
 # subdirectory of permanent_store with the name being the value of

--- a/old/__init__.py
+++ b/old/__init__.py
@@ -352,5 +352,4 @@ def main(global_config, **settings):
     config = Configurator(settings=settings, request_factory=MyRequest)
     config.include('.routes')
     config.add_renderer('json', get_json_renderer())
-    config.scan()
     return OLDHeadersMiddleware(config.make_wsgi_app())

--- a/old/tests/functional/test_applicationsettings.py
+++ b/old/tests/functional/test_applicationsettings.py
@@ -359,12 +359,6 @@ class TestApplicationsettingsView(TestView):
             'There is no application settings with id %s' % id
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-                                    extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
-
         # Unauthorized delete attempt as contributor
         response = self.app.post(url('create'), params,
                                     self.json_headers, self.extra_environ_admin)
@@ -393,12 +387,6 @@ class TestApplicationsettingsView(TestView):
                             extra_environ=self.extra_environ_admin, status=404)
         assert response.json_body['error'] == 'There is no application settings with id %s' % id
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-                                extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
 
         # Add the default application settings.
         application_settings = add_default_application_settings(self.dbsession)
@@ -442,12 +430,6 @@ class TestApplicationsettingsView(TestView):
         assert response.json_body['error'] == \
             'There is no application settings with id %s' % id
         assert response.content_type == 'application/json'
-
-        # No id: expect 404 Not Found
-        response = self.app.get(url('edit', id=''),
-            status=404, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
 
         # Add the default application settings.
         application_settings = add_default_application_settings(self.dbsession)

--- a/old/tests/functional/test_auth.py
+++ b/old/tests/functional/test_auth.py
@@ -107,10 +107,6 @@ class TestLogin(TestView):
             print(msg)
             assert True
             return
-        assert False
-
-        LOGGER.info('MUSTANG')
-        print('MUSTANG')
 
         # Create an application settings so that there is an object
         # language id

--- a/old/tests/functional/test_collections.py
+++ b/old/tests/functional/test_collections.py
@@ -1569,12 +1569,6 @@ class TestCollectionsView(TestView):
         assert 'There is no collection with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
     def test_show(self):
         """Tests that GET /collection/id returns a JSON collection object, null or 404
         depending on whether the id is valid, invalid or unspecified, respectively.
@@ -1596,13 +1590,6 @@ class TestCollectionsView(TestView):
             status=404)
         resp = response.json_body
         assert 'There is no collection with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id
@@ -1736,12 +1723,6 @@ class TestCollectionsView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin,
             status=404)
         assert 'There is no collection with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id

--- a/old/tests/functional/test_corpora.py
+++ b/old/tests/functional/test_corpora.py
@@ -651,12 +651,6 @@ class TestCorporaView(TestView):
         assert 'There is no corpus with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
     def test_show(self):
         """Tests that GET /corpora/id returns the corpus with id=id or an appropriate error."""
 
@@ -728,12 +722,6 @@ class TestCorporaView(TestView):
             status=404)
         resp = response.json_body
         assert 'There is no corpus with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id
@@ -826,12 +814,6 @@ class TestCorporaView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin,
             status=404)
         assert 'There is no corpus with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Get the data currently in the db (see websetup.py for the test data).

--- a/old/tests/functional/test_elicitationmethods.py
+++ b/old/tests/functional/test_elicitationmethods.py
@@ -247,11 +247,6 @@ class TestElicitationMethodsView(TestView):
         assert 'There is no elicitation method with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-
     def test_show(self):
         """Tests that GET /elicitationmethods/id returns the elicitation method with id=id or an appropriate error."""
 
@@ -273,11 +268,6 @@ class TestElicitationMethodsView(TestView):
         resp = response.json_body
         assert 'There is no elicitation method with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('show', id=elicitation_method_id), headers=self.json_headers,
@@ -318,12 +308,6 @@ class TestElicitationMethodsView(TestView):
             status=404)
         assert 'There is no elicitation method with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('edit', id=elicitation_method_id),

--- a/old/tests/functional/test_files.py
+++ b/old/tests/functional/test_files.py
@@ -1582,12 +1582,6 @@ class TestFilesView(TestView):
         assert 'There is no file with id %s' % id_ in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
-
         # Create and delete a file with unicode characters in the file name
         extra_environ = {'test.authentication.id': my_contributor_id}
         params = self.file_create_params_base64.copy()
@@ -1737,12 +1731,6 @@ class TestFilesView(TestView):
         assert 'There is no file with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
-
         # Now test that the restricted tag is working correctly.
         # First get the default contributor's id.
         users = db.get_users()
@@ -1883,12 +1871,6 @@ class TestFilesView(TestView):
             status=404)
         assert 'There is no file with id %s' % id_ in response.json_body['error']
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('edit', id=restricted_file_id),

--- a/old/tests/functional/test_forms.py
+++ b/old/tests/functional/test_forms.py
@@ -1613,13 +1613,6 @@ class TestFormsView(TestView):
         assert ('There is no form with id %s' % id_ in
                 response.json_body[ 'error'])
 
-        # Delete without an id
-        response = self.app.delete(
-            url('delete', id=''), status=404, headers=self.json_headers,
-            extra_environ=self.extra_environ_admin)
-        assert (response.json_body['error'] == 'The resource could not be'
-                ' found.')
-
     def test_delete_foreign_word(self):
         """Tests that DELETE /forms/id on a foreign word updates the global
         Inventory objects correctly.
@@ -1722,12 +1715,6 @@ class TestFormsView(TestView):
         assert response.content_type == 'application/json'
         assert 'There is no form with id %s' % id_ in response.json_body[
             'error']
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('show', id=form_id), headers=self.json_headers,
@@ -1870,13 +1857,6 @@ class TestFormsView(TestView):
             status=404)
         assert 'There is no form with id %s' % id_ in response.json_body[
             'error']
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
-        assert response.content_type == 'application/json'
 
         # Valid id
         response = self.app.get(url('edit', id=restricted_form_id),

--- a/old/tests/functional/test_formsearches.py
+++ b/old/tests/functional/test_formsearches.py
@@ -369,11 +369,6 @@ class TestFormsearchesView(TestView):
         assert 'There is no form search with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-
     def test_show(self):
         """Tests that GET /formsearches/id returns the formsearch with id=id or an appropriate error."""
 
@@ -403,11 +398,6 @@ class TestFormsearchesView(TestView):
         resp = response.json_body
         assert 'There is no form search with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('show', id=form_search_id), headers=self.json_headers,
@@ -456,11 +446,6 @@ class TestFormsearchesView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin, status=404)
         assert 'There is no form search with id {}'.format(id) in response.json_body['error']
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('edit', id=form_search_id),

--- a/old/tests/functional/test_morphemelanguagemodels.py
+++ b/old/tests/functional/test_morphemelanguagemodels.py
@@ -518,12 +518,6 @@ class TestMorphemelanguagemodelsView(TestView):
         assert 'There is no morpheme language model with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
         # Valid id
         response = self.app.get(url('show', id=morpheme_language_models[0].id), headers=self.json_headers,
                                 extra_environ=self.extra_environ_admin)
@@ -565,12 +559,6 @@ class TestMorphemelanguagemodelsView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin,
             status=404)
         assert 'There is no morpheme language model with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id

--- a/old/tests/functional/test_morphologicalparsers.py
+++ b/old/tests/functional/test_morphologicalparsers.py
@@ -1065,12 +1065,6 @@ define phonology eDrop .o. breakDrop;
         assert 'There is no morphological parser with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
         # Valid id
         response = self.app.get(url('show', id=morphological_parsers[0].id), headers=self.json_headers,
                                 extra_environ=self.extra_environ_admin)
@@ -1101,12 +1095,6 @@ define phonology eDrop .o. breakDrop;
             headers=self.json_headers, extra_environ=self.extra_environ_admin,
             status=404)
         assert 'There is no morphological parser with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id

--- a/old/tests/functional/test_morphologies.py
+++ b/old/tests/functional/test_morphologies.py
@@ -867,12 +867,6 @@ class TestMorphologiesView(TestView):
         assert 'There is no morphology with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
         # Valid id
         response = self.app.get(
             url('show', id=morphologies[0].id), headers=self.json_headers,
@@ -909,12 +903,6 @@ class TestMorphologiesView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin,
             status=404)
         assert 'There is no morphology with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id

--- a/old/tests/functional/test_orthographies.py
+++ b/old/tests/functional/test_orthographies.py
@@ -370,12 +370,6 @@ class TestOrthographiesView(TestView):
         assert 'There is no orthography with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
         # Observe how deletions are restricted when an orthography is part of an
         # active application settings ...
 
@@ -443,12 +437,6 @@ class TestOrthographiesView(TestView):
         assert 'There is no orthography with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
         # Valid id
         response = self.app.get(url('show', id=orthography_id), headers=self.json_headers,
                                 extra_environ=self.extra_environ_admin)
@@ -493,11 +481,6 @@ class TestOrthographiesView(TestView):
             status=404)
         assert 'There is no orthography with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('edit', id=orthography_id),

--- a/old/tests/functional/test_pages.py
+++ b/old/tests/functional/test_pages.py
@@ -298,11 +298,6 @@ class TestPagesView(TestView):
         assert 'There is no page with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-
     def test_show(self):
         """Tests that GET /pages/id returns the page with id=id or an appropriate error."""
 
@@ -328,12 +323,6 @@ class TestPagesView(TestView):
             status=404)
         resp = response.json_body
         assert 'There is no page with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id
@@ -379,11 +368,6 @@ class TestPagesView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin, status=404)
         assert 'There is no page with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('edit', id=page_id),

--- a/old/tests/functional/test_phonologies.py
+++ b/old/tests/functional/test_phonologies.py
@@ -415,12 +415,6 @@ class TestPhonologiesView(TestView):
         assert 'There is no phonology with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
     def test_show(self):
         """Tests that GET /phonologies/id returns the phonology with id=id or an appropriate error."""
 
@@ -451,12 +445,6 @@ class TestPhonologiesView(TestView):
             status=404)
         resp = response.json_body
         assert 'There is no phonology with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id
@@ -508,12 +496,6 @@ class TestPhonologiesView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin,
             status=404)
         assert 'There is no phonology with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id

--- a/old/tests/functional/test_sources.py
+++ b/old/tests/functional/test_sources.py
@@ -886,12 +886,6 @@ class TestSourcesView(TestView):
         assert 'There is no source with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
     def test_show(self):
         """Tests that GET /source/id returns the source with id=id or an appropriate error."""
 
@@ -921,12 +915,6 @@ class TestSourcesView(TestView):
             status=404)
         resp = response.json_body
         assert 'There is no source with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id
@@ -977,12 +965,6 @@ class TestSourcesView(TestView):
             status=404)
         assert 'There is no source with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == \
-            'The resource could not be found.'
 
         # Valid id
         response = self.app.get(url('edit', id=book_id),

--- a/old/tests/functional/test_speakers.py
+++ b/old/tests/functional/test_speakers.py
@@ -276,12 +276,6 @@ class TestSpeakersView(TestView):
         assert 'There is no speaker with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
     def test_show(self):
         """Tests that GET /speakers/id returns the speaker with id=id or an appropriate error."""
 
@@ -309,12 +303,6 @@ class TestSpeakersView(TestView):
             status=404)
         resp = response.json_body
         assert 'There is no speaker with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id
@@ -362,12 +350,6 @@ class TestSpeakersView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin,
             status=404)
         assert 'There is no speaker with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id

--- a/old/tests/functional/test_syntacticcategories.py
+++ b/old/tests/functional/test_syntacticcategories.py
@@ -263,12 +263,6 @@ class TestSyntacticcategoriesView(TestView):
         assert 'There is no syntactic category with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
     def test_show(self):
         """Tests that GET /syntacticcategories/id returns the syntactic category with id=id or an appropriate error."""
 
@@ -289,12 +283,6 @@ class TestSyntacticcategoriesView(TestView):
             status=404)
         resp = response.json_body
         assert 'There is no syntactic category with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id
@@ -335,12 +323,6 @@ class TestSyntacticcategoriesView(TestView):
             headers=self.json_headers, extra_environ=self.extra_environ_admin,
             status=404)
         assert 'There is no syntactic category with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id

--- a/old/tests/functional/test_tags.py
+++ b/old/tests/functional/test_tags.py
@@ -302,15 +302,6 @@ class TestTagsView(TestView):
                 resp['error'])
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        tag_id = ''
-        response = self.app.delete(
-            url('delete', id=tag_id), status=404, headers=self.json_headers,
-            extra_environ=self.extra_environ_admin)
-        resp = response.json_body
-        assert resp['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
         # TODO: uncomment this once forms view implemented.
         """
         # Create a form, tag it, delete the tag and show that the form no
@@ -356,14 +347,6 @@ class TestTagsView(TestView):
         assert 'There is no tag with id %s' % id_ in resp['error']
         assert response.content_type == 'application/json'
 
-        # No id
-        response = self.app.get(
-            url('show', id=''), status=404, headers=self.json_headers,
-            extra_environ=self.extra_environ_admin)
-        resp = response.json_body
-        assert resp['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
         # Valid id
         response = self.app.get(
             url('show', id=tag_id), headers=self.json_headers,
@@ -407,14 +390,6 @@ class TestTagsView(TestView):
             extra_environ=self.extra_environ_admin, status=404)
         resp = response.json_body
         assert 'There is no tag with id %s' % id_ in resp['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(
-            url('edit_tag', id=''), status=404, headers=self.json_headers,
-            extra_environ=self.extra_environ_admin)
-        resp = response.json_body
-        assert resp['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id

--- a/old/tests/functional/test_users.py
+++ b/old/tests/functional/test_users.py
@@ -974,12 +974,6 @@ class TestUsersView(TestView):
         assert 'There is no user with id %s' % id in response.json_body['error']
         assert response.content_type == 'application/json'
 
-        # Delete without an id
-        response = self.app.delete(url('delete', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
-        assert response.content_type == 'application/json'
-
     def test_show(self):
         """Tests that GET /users/id returns the user with id=id or an appropriate error."""
 
@@ -1018,12 +1012,6 @@ class TestUsersView(TestView):
                             extra_environ=self.extra_environ_admin, status=404)
         resp = response.json_body
         assert 'There is no user with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('show', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id (show that a viewer can GET a user too)
@@ -1101,12 +1089,6 @@ class TestUsersView(TestView):
         response = self.app.get(url('edit', id=id),
             headers=self.json_headers, extra_environ=self.extra_environ_admin, status=404)
         assert 'There is no user with id %s' % id in response.json_body['error']
-        assert response.content_type == 'application/json'
-
-        # No id
-        response = self.app.get(url('edit', id=''), status=404,
-            headers=self.json_headers, extra_environ=self.extra_environ_admin)
-        assert response.json_body['error'] == 'The resource could not be found.'
         assert response.content_type == 'application/json'
 
         # Valid id, admin

--- a/old/views/auth.py
+++ b/old/views/auth.py
@@ -100,9 +100,9 @@ def email_reset_password(request):
     """
     LOGGER.info('Request for a password reset.')
     schema = PasswordResetSchema()
-    if self.request.registry.settings.get('readonly') == '1':
+    if request.registry.settings.get('readonly') == '1':
         LOGGER.warning('Attempt to reset a password in read-only mode')
-        self.request.response.status_int = 403
+        request.response.status_int = 403
         return READONLY_MODE_MSG
     try:
         values = json.loads(request.body.decode(request.charset))


### PR DESCRIPTION
- Fix configlocal.ini so that it sets the readonly to 1 by default.
- Fix old/__init__.py so that it no longer calls config.scan(), which results in the default (config.ini) file being loaded after a specified (e.g., configlocal.ini) file has been loaded.