### PR TITLE
Allow for configuration of session secure and samesite attributes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -104,10 +104,11 @@ session.secret = db49238825c4409897b39f49f29e4d77
 # OLD_SESSION_COOKIE_EXPIRES
 session.cookie_expires = true
 
-# The following changes may be needed. See this issue in the
-# original OLD: https://github.com/dativebase/old/issues/94
-# session.secure = true
-# session.samesite = None
+# Whether or not the cookie should only be sent over SSL.
+session.secure = false
+
+# SameSite value for the cookie -- should be either Lax, Strict, or None.
+session.samesite = None
 
 # SQLAlchemy config
 # ------------------------------------------------------------------------------

--- a/old/__init__.py
+++ b/old/__init__.py
@@ -298,7 +298,9 @@ ENV_VAR_MAP = {
     'OLD_SESSION_DATA_DIR': 'session.data_dir',
     'OLD_SESSION_LOCK_DIR': 'session.lock_dir',
     'OLD_SESSION_KEY': 'session.key',
+    'OLD_SESSION_SAMESITE': 'session.samesite',
     'OLD_SESSION_SECRET': 'session.secret',
+    'OLD_SESSION_SECURE': 'session.secure',
     'OLD_SESSION_COOKIE_EXPIRES': 'session.cookie_expires'
 }
 


### PR DESCRIPTION
[Fixes 51]( https://github.com/dativebase/old-pyramid/issues/51)

## Rationale

The samesite cookie attribute needs to be set to `None` in order for Dative to be able to store OLD cookies when the two apps are on different URLs.

## Considerations

In prod, `session.secure` should be `True` so that cookies only work over HTTPS. However, in local development doing this will break integration tests.

## Changes

- Allow for configuration of session secure and samesite attributes.
  - Modify `config.ini` to accept these values with defaults `false` and `None`, respectively.
  - Modify `old/__init__.py` so that:
    - the env var `OLD_SESSION_SECURE` can override the `config.ini` `session.secure` value, and
    - the env var `OLD_SESSION_SAMESITE` can override the `config.ini` `session.samesite` value.