### PR TITLE
Stop session lock_dir from growing unboundedly

### DIFF
--- a/old/__init__.py
+++ b/old/__init__.py
@@ -247,7 +247,7 @@ class MyRequest(Request):
         if os.path.basename(self.registry.settings[
                 'session.lock_dir'].rstrip('/')) != self.old_name:
             self.registry.settings['session.lock_dir'] = os.path.join(
-                self.registry.settings['session.lock_dir'],
+                os.path.dirname(self.registry.settings['session.lock_dir']),
                 self.registry.settings['old_name'])
         if not self.registry.settings['session.key'].endswith(
                 '_{}'.format(self.old_name)):


### PR DESCRIPTION
[Fixes 52](https://github.com/dativebase/old-pyramid/issues/52)

## Rationale

We want users to be able to log in and out of different OLD instances from a single Dative without getting blocked by 500 responses!!!

## Considerations.

I added no new tests, but in-dev print statements show the original issue and how this fix resolved it.

Past bad behaviour:

```
  OLD Name: oldtests2
  session.lock_dir: oldtests
  New session lock_dir: /var/old/data/sessions/lock/oldtests/oldtests2/oldtests/oldtests2/oldtests/oldtests2
  OLD Name: oldtests
  session.lock_dir: oldtests2
  New session lock_dir: /var/old/data/sessions/lock/oldtests/oldtests2/oldtests/oldtests2/oldtests/oldtests2/oldtests
```

Current good behaviour:

```
  OLD Name: oldtests
  session.lock_dir: lock
  New session lock_dir: /var/old/data/sessions/oldtests
  OLD Name: oldtests2
  session.lock_dir: oldtests
  New session lock_dir: /var/old/data/sessions/oldtests2
```

## Changes

- Ensure when we construct an OLD-instance-specific lock_dir value for the Beaker session that we do not simply append the current OLD name to the existing path. That simply results in an ever-growing path, which results in 500 errors eventually.