### PR TITLE
Set session key to OLD name

### DIFF
--- a/old/__init__.py
+++ b/old/__init__.py
@@ -251,8 +251,7 @@ class MyRequest(Request):
                 self.registry.settings['old_name'])
         if not self.registry.settings['session.key'].endswith(
                 '_{}'.format(self.old_name)):
-            self.registry.settings['session.key'] = '{}_{}'.format(
-                self.registry.settings['session.key'],
+            self.registry.settings['session.key'] = 'old_{}'.format(
                 self.registry.settings['old_name'])
         self._beakersession = beaker_session_factory.get_session(
             self.registry.settings)(self)


### PR DESCRIPTION
Fixes https://github.com/dativebase/old-pyramid/issues/54

## Rationale

We want users to be able to login and out of multiple OLD instances from a single Dative session. Right now, if you do this too often, you will fail after not too long. The underlying issue is that we just append the current OLD instance's name to the session cookie's key value until it becomes longer than the cookie spec tolerates.

## Changes

Stop appending the current OLD key name to the session key. Just replace it with `old_<OLD_INSTANCE_NAME>`.