### PR TITLE
Default session secure attribute to true

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             OLD_TESTING: "1"
             OLD_DB_RDBMS: "sqlite"
             OLD_SESSION_TYPE: "file"
+            OLD_SESSION_SECURE: 0
             SMTP_SERVER_ABSENT: "1"
           command: python -m pytest old\tests -v -x
       - run:
@@ -43,6 +44,7 @@ jobs:
             OLD_READONLY: "1"
             OLD_DB_RDBMS: "sqlite"
             OLD_SESSION_TYPE: "file"
+            OLD_SESSION_SECURE: 0
             SMTP_SERVER_ABSENT: "1"
           command: python -m pytest old\tests\functional\test_readonly_mode.py::TestReadonlyMode::test_readonly_mode -v -x
 
@@ -86,6 +88,7 @@ jobs:
            OLD_NAME_2_TESTS: "oldtests2"
            OLD_PERMANENT_STORE: "/var/old/store"
            OLD_TESTING: 1
+           OLD_SESSION_SECURE: 0
            SMTP_SERVER_ABSENT: "1"
          command: "/venv/bin/pytest old/tests/ -v"
       - run:
@@ -97,6 +100,7 @@ jobs:
             OLD_READONLY: "1"
             OLD_DB_RDBMS: "sqlite"
             OLD_SESSION_TYPE: "file"
+            OLD_SESSION_SECURE: 0
             SMTP_SERVER_ABSENT: "1"
           command: "/venv/bin/pytest old/tests/functional/test_readonly_mode.py::TestReadonlyMode::test_readonly_mode -v"
 

--- a/config.ini
+++ b/config.ini
@@ -105,9 +105,11 @@ session.secret = db49238825c4409897b39f49f29e4d77
 session.cookie_expires = true
 
 # Whether or not the cookie should only be sent over SSL.
-session.secure = false
+# OLD_SESSION_SECURE
+session.secure = true
 
 # SameSite value for the cookie -- should be either Lax, Strict, or None.
+# OLD_SESSION_SAMESITE
 session.samesite = None
 
 # SQLAlchemy config


### PR DESCRIPTION
Ensure that the cookies sent by the OLD have the secure attribute set by default. This can still be disabled by setting the env var 'OLD_SESSION_SECURE' to `'false'`, or by modifying `config.ini` directly.

## Rationale

Modern browsers now require HTTPS to be used and the `secure` flag enabled in order to use `samesite=None`, which is what Dative/OLD does because we want to allow cross-origin requests that are authorized via cookie sessions.
